### PR TITLE
Reset internal flags so that the library works if called a second time.

### DIFF
--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -220,6 +220,9 @@ public class D3SView extends WebView
 
         if (authorizationListener != null)
         {
+            // reset these flags for next time.
+            urlReturned = false;
+            postbackHandled = false;
             authorizationListener.onAuthorizationCompleted(md, pares);
         }
     }


### PR DESCRIPTION
If the D3SView was opened a second time the Javascript hooks were not being called. Needed to reset some internal flags. 
